### PR TITLE
Allow returns to take multiple values

### DIFF
--- a/projects/moq/src/integration.specs/instance-method.spec.ts
+++ b/projects/moq/src/integration.specs/instance-method.spec.ts
@@ -17,9 +17,20 @@ describe("Instance method", () => {
             .returns(value)
             .object();
 
-        const actual = object.method(1);
+        expect(object.method(1)).toBe(value);
+        expect(object.method(1)).toBe(value);
+    });
 
-        expect(actual).toBe(value);
+    it("Returns values with a simple setup", () => {
+        const object = new Mock<ITestObject>()
+            .setup(instance => instance.method(1))
+            .returns("first", "second", "last")
+            .object();
+
+        expect(object.method(1)).toBe("first");
+        expect(object.method(1)).toBe("second");
+        expect(object.method(1)).toBe("last");
+        expect(object.method(1)).toBe("last");
     });
 
     it("Returns value with a predicated setup", () => {

--- a/projects/moq/src/integration.specs/issue578.spec.ts
+++ b/projects/moq/src/integration.specs/issue578.spec.ts
@@ -31,6 +31,22 @@ describe("#578 support async functions", () => {
         expect(actual).toBe(2);
     });
 
+    it("returns async for multiple values", async () => {
+        async function fn(): Promise<string> {
+            return "";
+        }
+
+        const mock = new Mock<typeof fn>()
+            .setup(async instance => instance())
+            .returnsAsync("first", "second", "last")
+            .object();
+
+        expect(await mock()).toBe("first");
+        expect(await mock()).toBe("second");
+        expect(await mock()).toBe("last");
+        expect(await mock()).toBe("last");
+    });
+
     it("throws async", async () => {
         async function fn() {
             return 1;

--- a/projects/moq/src/lib/interaction-players/preset.player.spec.ts
+++ b/projects/moq/src/lib/interaction-players/preset.player.spec.ts
@@ -16,13 +16,15 @@ describe("Preset player", () => {
     it("Plays returns preset and returns result", () => {
         const expression = {} as Expression;
 
-        const value = "value";
-        const preset = new ReturnsPreset<unknown, string>(undefined, undefined, value);
+        const values = ["first", "second", "last"];
+        const preset = new ReturnsPreset<unknown, string>(undefined, undefined, values);
 
         const player = resolve2(PresetPlayer);
-        const actual = player.play(preset, expression);
 
-        expect(actual).toBe(value);
+        expect(player.play(preset, expression)).toBe(values[0]);
+        expect(player.play(preset, expression)).toBe(values[1]);
+        expect(player.play(preset, expression)).toBe(values[2]);
+        expect(player.play(preset, expression)).toBe(values[2]);
     });
 
     it("Plays callback preset and returns result", () => {

--- a/projects/moq/src/lib/interaction-players/preset.player.ts
+++ b/projects/moq/src/lib/interaction-players/preset.player.ts
@@ -19,7 +19,7 @@ export class PresetPlayer {
 
     public play<T>(preset: IPreset<T>, interaction: Expression): any {
         if (preset instanceof ReturnsPreset) {
-            return preset.value;
+            return preset.nextValue();
         }
         if (preset instanceof CallbacksPreset) {
             return this.callbackPresetPlayer.play(preset.callback, interaction);

--- a/projects/moq/src/lib/moq.ts
+++ b/projects/moq/src/lib/moq.ts
@@ -65,23 +65,28 @@ export interface IPlayable {
  */
 export interface IPresetBuilder<T, TValue = any> {
     /**
-     * Returns the provided value as a result of interaction in case of
+     * Returns the provided values as a result of interaction in case of
      * - get property value
      * - invocation a function
      *
      * Controls write operation in case of
      * - property assignment (true - the assignment is allowed, false - the assignment is not allowed)
      *
-     * @param value The value
+     * When the values are exhausted, the last given value is returned for
+     * subsequent calls.
+     *
+     * @param value The first value to return
+     * @param otherValues Other values to return
      */
-    returns(value: TValue): IMock<T>;
+    returns(value: TValue, ...otherValues: TValue[]): IMock<T>;
 
     /**
-     * Returns the provided value with a resolved Promise as a result of invocation an asynchronous function
+     * Returns the provided values with resolved promises as a result of invocations of an asynchronous function
      *
      * @param value The value
+     * @param otherValues Other values to return
      */
-    returnsAsync(value: PromisedType<TValue>): IMock<T>;
+    returnsAsync(value: PromisedType<TValue>, ...otherValues: PromisedType<TValue>[]): IMock<T>;
 
     /**
      * Throws the provided exception.

--- a/projects/moq/src/lib/presets/factories/returns-async-preset.factory.spec.ts
+++ b/projects/moq/src/lib/presets/factories/returns-async-preset.factory.spec.ts
@@ -31,9 +31,9 @@ describe("Returns async preset factory", () => {
             .returns(promise);
 
         const builder = resolve2<ReturnsAsyncPresetFactory<any, Promise<string>>>(ReturnsAsyncPresetFactory);
-        const actual = builder(target, playable, value);
+        const actual = builder(target, playable, [value]);
 
-        const expected = new ReturnsPreset(playable, target, promise);
+        const expected = new ReturnsPreset(playable, target, [promise]);
         resolveMock(Presets).verify(instance => instance.add(expected));
         expect(actual).toBe(resolve2(Mock));
     });

--- a/projects/moq/src/lib/presets/factories/returns-async-preset.factory.ts
+++ b/projects/moq/src/lib/presets/factories/returns-async-preset.factory.ts
@@ -16,8 +16,8 @@ export class ReturnsAsyncPresetFactory<T, TValue = any> implements InjectionFact
     }
 
     factory() {
-        return (target: Expressions<T>, playable: IPlayable, value: PromisedType<TValue>) => {
-            const preset = new ReturnsPreset(playable, target, this.resolvedPromise(value));
+        return (target: Expressions<T>, playable: IPlayable, values: PromisedType<TValue>[]) => {
+            const preset = new ReturnsPreset(playable, target, values.map(v => this.resolvedPromise(v)));
             this.presets.add(preset);
             return this.rootMock;
         };

--- a/projects/moq/src/lib/presets/factories/returns-preset.factory.spec.ts
+++ b/projects/moq/src/lib/presets/factories/returns-preset.factory.spec.ts
@@ -25,9 +25,9 @@ describe("Returns preset factory", () => {
         const playable = PlayTimes.Always();
 
         const builder = resolve2(ReturnsPresetFactory);
-        const actual = builder(target, playable, value);
+        const actual = builder(target, playable, [value]);
 
-        const expected = new ReturnsPreset(playable, target, value);
+        const expected = new ReturnsPreset(playable, target, [value]);
         resolveMock(Presets).verify(instance => instance.add(expected));
         expect(actual).toBe(resolve2(Mock));
     });

--- a/projects/moq/src/lib/presets/factories/returns-preset.factory.ts
+++ b/projects/moq/src/lib/presets/factories/returns-preset.factory.ts
@@ -14,8 +14,8 @@ export class ReturnsPresetFactory<T, TValue = any> implements InjectionFactory {
     }
 
     factory() {
-        return (target: Expressions<T>, playable: IPlayable, value: TValue) => {
-            const preset = new ReturnsPreset(playable, target, value);
+        return (target: Expressions<T>, playable: IPlayable, values: TValue[]) => {
+            const preset = new ReturnsPreset(playable, target, values);
             this.presets.add(preset);
             return this.rootMock;
         };

--- a/projects/moq/src/lib/presets/factories/throws-async-preset.factory.spec.ts
+++ b/projects/moq/src/lib/presets/factories/throws-async-preset.factory.spec.ts
@@ -33,7 +33,7 @@ describe("Throws async preset factory", () => {
         const builder = resolve2(ThrowsAsyncPresetFactory);
         const actual = builder(target, playable, exception);
 
-        const expected = new ReturnsPreset(playable, target, promise);
+        const expected = new ReturnsPreset(playable, target, [promise]);
         resolveMock(Presets).verify(instance => instance.add(expected));
         expect(actual).toBe(resolve2(Mock));
     });

--- a/projects/moq/src/lib/presets/factories/throws-async-preset.factory.ts
+++ b/projects/moq/src/lib/presets/factories/throws-async-preset.factory.ts
@@ -17,7 +17,7 @@ export class ThrowsAsyncPresetFactory<T, TValue = any> implements InjectionFacto
 
     factory() {
         return <TException>(target: Expressions<T>, playable: IPlayable, exception: TException) => {
-            const preset = new ReturnsPreset(playable, target, this.rejectedPromise(exception));
+            const preset = new ReturnsPreset(playable, target, [this.rejectedPromise(exception)]);
             this.presets.add(preset);
             return this.rootMock;
         };

--- a/projects/moq/src/lib/presets/preset-builder.spec.ts
+++ b/projects/moq/src/lib/presets/preset-builder.spec.ts
@@ -44,7 +44,7 @@ describe("Preset builder", () => {
         const root = {} as IMock<any>;
 
         resolveMock(ReturnsPresetFactory)
-            .setup(instance => instance(resolve2(Target), PlayTimes.Always(), value))
+            .setup(instance => instance(resolve2(Target), PlayTimes.Always(), [value]))
             .returns(root);
 
         const builder = resolve2(PresetBuilder);
@@ -86,7 +86,7 @@ describe("Preset builder", () => {
         const root = {} as IMock<any>;
 
         resolveMock<ReturnsAsyncPresetFactory<any, Promise<string>>>(ReturnsAsyncPresetFactory)
-            .setup(instance => instance(resolve2(Target), PlayTimes.Always(), value))
+            .setup(instance => instance(resolve2(Target), PlayTimes.Always(), [value]))
             .returns(root);
 
         const builder = resolve2<PresetBuilder<any, Promise<string>>>(PresetBuilder);
@@ -122,12 +122,12 @@ describe("Preset builder", () => {
         builder.throwsAsync(undefined);
 
         const target = resolve2(Target);
-        resolveMock(ReturnsPresetFactory).verify(instance => instance(target, playable, undefined));
+        resolveMock(ReturnsPresetFactory).verify(instance => instance(target, playable, [undefined]));
         resolveMock(ThrowsPresetFactory).verify(instance => instance(target, playable, undefined));
         resolveMock(MimicsPresetFactory).verify(instance => instance(target, playable, undefined));
         resolveMock(CallbackPresetFactory).verify(instance => instance(target, playable, undefined));
         resolveMock<ReturnsAsyncPresetFactory<any>>(ReturnsAsyncPresetFactory)
-            .verify(instance => instance(target, playable, undefined));
+            .verify(instance => instance(target, playable, [undefined]));
         resolveMock(ThrowsAsyncPresetFactory).verify(instance => instance(target, playable, undefined));
         expect(actual).toBe(builder);
     });

--- a/projects/moq/src/lib/presets/preset-builder.ts
+++ b/projects/moq/src/lib/presets/preset-builder.ts
@@ -30,8 +30,8 @@ export class PresetBuilder<T, TValue = any> implements IPresetBuilder<T> {
 
     }
 
-    public returnsAsync(value: PromisedType<TValue>): IMock<T> {
-        return this.returnsAsyncPresetFactory(this.target, this.playable, value);
+    public returnsAsync(value: PromisedType<TValue>, ...otherValues: PromisedType<TValue>[]): IMock<T> {
+        return this.returnsAsyncPresetFactory(this.target, this.playable, [value, ...otherValues]);
     }
 
     public throwsAsync<TException>(exception: TException): IMock<T> {
@@ -42,8 +42,8 @@ export class PresetBuilder<T, TValue = any> implements IPresetBuilder<T> {
         return this.mimicsPresetFactory(this.target, this.playable, origin);
     }
 
-    public returns(value: TValue): IMock<T> {
-        return this.returnsPresetFactory(this.target, this.playable, value);
+    public returns(value: TValue, ...otherValues: TValue[]): IMock<T> {
+        return this.returnsPresetFactory(this.target, this.playable, [value, ...otherValues]);
     }
 
     public throws<TException>(exception: TException): IMock<T> {

--- a/projects/moq/src/lib/presets/presets/returns.preset.ts
+++ b/projects/moq/src/lib/presets/presets/returns.preset.ts
@@ -3,11 +3,21 @@ import { Expressions } from "../../reflector/expressions";
 import { IPlayable } from "../../moq";
 
 export class ReturnsPreset<T, TValue> implements IPreset<T> {
+    private valuesIndex = 0;
+
     constructor(
         public readonly playable: IPlayable,
         public readonly target: Expressions<T>,
-        public readonly value: TValue) {
+        private readonly values: TValue[]) {
 
+    }
+
+    public nextValue(): TValue {
+        const value = this.values[this.valuesIndex];
+        if (this.valuesIndex < this.values.length - 1) {
+            this.valuesIndex++;
+        }
+        return value;
     }
 }
 


### PR DESCRIPTION
This implements https://github.com/dvabuzyarov/moq.ts/issues/827.

For each time the setup is invoked, this returns each given value sequentially until it reaches the last value, where it will return the last value for all subsequent calls.